### PR TITLE
[codex] Guard Intercom calls before initialization

### DIFF
--- a/android/src/main/kotlin/com/example/flutter_intercom/FlutterIntercomPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_intercom/FlutterIntercomPlugin.kt
@@ -24,6 +24,10 @@ class FlutterIntercomPlugin: FlutterPlugin, MethodCallHandler {
   private lateinit var channel : MethodChannel
   private var application: Application? = null
 
+  companion object {
+    private var isInitialized = false
+  }
+
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     application = flutterPluginBinding.applicationContext as Application
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "flutter_intercom")
@@ -37,15 +41,33 @@ class FlutterIntercomPlugin: FlutterPlugin, MethodCallHandler {
         val apiKey = args?.get("apiKey") as? String
         val appId = args?.get("appId") as? String
 
-        if (apiKey != null && appId != null) {
-          Intercom.initialize(application, apiKey, appId)
+        val app = application
+        if (apiKey != null && appId != null && app != null) {
+          try {
+            Intercom.initialize(app, apiKey, appId)
+            isInitialized = true
+          } catch (e: Exception) {
+            isInitialized = false
+            result.error("INTERCOM_INITIALIZE_ERROR", e.message, null)
+            return
+          }
           result.success("Success")
         } else {
+          isInitialized = false
           result.error("ERROR", "Invalid arguments", null)
         }
       }
 
       "loginUnidentifiedUser" -> {
+        if (!isInitialized) {
+          result.success(
+            mapOf(
+              "success" to false,
+              "message" to "Intercom has not been initialized."
+            )
+          )
+          return
+        }
         Intercom.client().loginUnidentifiedUser(
           intercomStatusCallback = object : IntercomStatusCallback {
             override fun onSuccess() {
@@ -71,6 +93,15 @@ class FlutterIntercomPlugin: FlutterPlugin, MethodCallHandler {
       }
 
       "loginUser" -> {
+        if (!isInitialized) {
+          result.success(
+            mapOf(
+              "success" to false,
+              "message" to "Intercom has not been initialized."
+            )
+          )
+          return
+        }
         val args = call.arguments as? Map<*, *>
         val userId = args?.get("userId") as String? ?: ""
         val email = args?.get("email") as String? ?: ""
@@ -119,6 +150,10 @@ class FlutterIntercomPlugin: FlutterPlugin, MethodCallHandler {
       }
 
       "setUserHash" -> {
+        if (!isInitialized) {
+          result.success("Skipped")
+          return
+        }
         val args = call.arguments as? Map<*, *>
         val hash = args?.get("hash") as? String
         if (hash != null) {
@@ -128,6 +163,10 @@ class FlutterIntercomPlugin: FlutterPlugin, MethodCallHandler {
       }
 
       "present" -> {
+        if (!isInitialized) {
+          result.success("Skipped")
+          return
+        }
         val args = call.arguments as? Map<*, *>
         val space = args?.get("space") as? String
 
@@ -142,14 +181,24 @@ class FlutterIntercomPlugin: FlutterPlugin, MethodCallHandler {
       }
 
       "hide" -> {
+        if (!isInitialized) {
+          result.success("Skipped")
+          return
+        }
         Intercom.client().hideIntercom()
         result.success("Success")
       }
 
       "logout" -> {
+        if (!isInitialized) {
+          result.success("Skipped")
+          return
+        }
         try {
           Intercom.client().logout()
+          isInitialized = false
         } catch (e: IllegalStateException) {
+          isInitialized = false
           e.message?.let { Log.e("Intercom", it) }
         }
         result.success("Success")

--- a/ios/Classes/FlutterIntercomPlugin.swift
+++ b/ios/Classes/FlutterIntercomPlugin.swift
@@ -3,6 +3,8 @@ import UIKit
 import Intercom
 
 public class FlutterIntercomPlugin: NSObject, FlutterPlugin {
+    private static var isInitialized = false
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "flutter_intercom", binaryMessenger: registrar.messenger())
         let instance = FlutterIntercomPlugin()
@@ -16,12 +18,21 @@ public class FlutterIntercomPlugin: NSObject, FlutterPlugin {
                let apiKey = args["apiKey"] as? String,
                let appId = args["appId"] as? String {
                 Intercom.setApiKey(apiKey, forAppId: appId)
+                FlutterIntercomPlugin.isInitialized = true
                 result("Success")
             } else {
+                FlutterIntercomPlugin.isInitialized = false
                 result(FlutterError(code: "ERROR", message: "Invalid arguments", details: nil))
             }
             return
         case "loginUnidentifiedUser":
+            guard FlutterIntercomPlugin.isInitialized else {
+                result([
+                    "success": false,
+                    "message": "Intercom has not been initialized.",
+                ])
+                return
+            }
             Intercom.loginUnidentifiedUser { res in
                 switch res {
                 case .success:
@@ -40,6 +51,13 @@ public class FlutterIntercomPlugin: NSObject, FlutterPlugin {
             }
             return
         case "loginUser":
+            guard FlutterIntercomPlugin.isInitialized else {
+                result([
+                    "success": false,
+                    "message": "Intercom has not been initialized.",
+                ])
+                return
+            }
             let attributes = ICMUserAttributes()
             if let args = call.arguments as? [String: Any] {
                 if let userId = args["userId"] as? String, !userId.isEmpty {
@@ -79,6 +97,10 @@ public class FlutterIntercomPlugin: NSObject, FlutterPlugin {
             }
             return
         case "setUserHash":
+            guard FlutterIntercomPlugin.isInitialized else {
+                result("Skipped")
+                return
+            }
             if let args = call.arguments as? [String: Any],
                let hash = args["hash"] as? String {
                 Intercom.setUserHash(hash)
@@ -86,6 +108,10 @@ public class FlutterIntercomPlugin: NSObject, FlutterPlugin {
             result("Success")
             return
         case "present":
+            guard FlutterIntercomPlugin.isInitialized else {
+                result("Skipped")
+                return
+            }
             if let args = call.arguments as? [String: Any],
                let space = args["space"] as? String {
                 switch space {
@@ -106,11 +132,20 @@ public class FlutterIntercomPlugin: NSObject, FlutterPlugin {
             result("Success")
             return
         case "hide":
+            guard FlutterIntercomPlugin.isInitialized else {
+                result("Skipped")
+                return
+            }
             Intercom.hide()
             result("Success")
             return
         case "logout":
+            guard FlutterIntercomPlugin.isInitialized else {
+                result("Skipped")
+                return
+            }
             Intercom.logout()
+            FlutterIntercomPlugin.isInitialized = false
             result("Success")
             return
         default:

--- a/lib/flutter_intercom.dart
+++ b/lib/flutter_intercom.dart
@@ -3,16 +3,14 @@ import 'package:flutter_intercom/models/intercom_user_attributes.dart';
 
 import 'flutter_intercom_platform_interface.dart';
 
-enum ICMSpace {
-  home,
-  helpCenter,
-  messages,
-  tickets,
-}
+enum ICMSpace { home, helpCenter, messages, tickets }
 
 class FlutterIntercom {
-  Future<void> setApiKeyForAppId({String? apiKey, String? appId}) {
-    return FlutterIntercomPlatform.instance.setApiKeyForAppId(apiKey: apiKey, appId: appId);
+  Future<void> setApiKeyForAppId({String? apiKey, String? appId}) async {
+    await FlutterIntercomPlatform.instance.setApiKeyForAppId(
+      apiKey: apiKey,
+      appId: appId,
+    );
   }
 
   Future<ICMLoginResult> loginUnidentifiedUser() {
@@ -27,19 +25,18 @@ class FlutterIntercom {
     return FlutterIntercomPlatform.instance.setUserHash(hash);
   }
 
-  Future<void> present({ICMSpace? space}) {
+  Future<void> present({ICMSpace? space}) async {
+    await FlutterIntercomPlatform.instance.present(space);
     FlutterIntercomPlatform.isPresent = true;
-    return FlutterIntercomPlatform.instance.present(space);
   }
 
   Future<void> hide() async {
-    if (FlutterIntercomPlatform.isPresent) {
-      await FlutterIntercomPlatform.instance.hide();
-      FlutterIntercomPlatform.isPresent = false;
-    }
+    await FlutterIntercomPlatform.instance.hide();
+    FlutterIntercomPlatform.isPresent = false;
   }
 
-  Future<void> logout() {
-    return FlutterIntercomPlatform.instance.logout();
+  Future<void> logout() async {
+    await FlutterIntercomPlatform.instance.logout();
+    FlutterIntercomPlatform.isPresent = false;
   }
 }

--- a/lib/flutter_intercom_method_channel.dart
+++ b/lib/flutter_intercom_method_channel.dart
@@ -14,42 +14,37 @@ class MethodChannelFlutterIntercom extends FlutterIntercomPlatform {
 
   @override
   Future<void> setApiKeyForAppId({String? apiKey, String? appId}) async {
-    try {
-      await methodChannel.invokeMethod<void>('setApiKeyForAppId', {
-        'apiKey': apiKey,
-        'appId': appId,
-      });
-    } catch (e) {
-      if (kDebugMode) {
-        print('Error setting API key for app ID: $e');
-      }
-    }
+    await methodChannel.invokeMethod<void>('setApiKeyForAppId', {
+      'apiKey': apiKey,
+      'appId': appId,
+    });
   }
 
   @override
   Future<ICMLoginResult> loginUnidentifiedUser() async {
-    final dynamic result = await methodChannel.invokeMethod<dynamic>('loginUnidentifiedUser');
+    final dynamic result = await methodChannel.invokeMethod<dynamic>(
+      'loginUnidentifiedUser',
+    );
     return ICMLoginResult.fromJson(result.cast<String, dynamic>());
   }
 
   @override
   Future<ICMLoginResult> loginUser(ICMUserAttributes userAttributes) async {
-    final dynamic result = await methodChannel.invokeMethod<dynamic>('loginUser', userAttributes.toJson());
+    final dynamic result = await methodChannel.invokeMethod<dynamic>(
+      'loginUser',
+      userAttributes.toJson(),
+    );
     return ICMLoginResult.fromJson(result.cast<String, dynamic>());
   }
 
   @override
   Future<void> setUserHash(String hash) async {
-    await methodChannel.invokeMethod<void>('setUserHash', {
-      'hash': hash,
-    });
+    await methodChannel.invokeMethod<void>('setUserHash', {'hash': hash});
   }
 
   @override
   Future<void> present(ICMSpace? space) async {
-    await methodChannel.invokeMethod<void>('present', {
-      'space': space?.name,
-    });
+    await methodChannel.invokeMethod<void>('present', {'space': space?.name});
   }
 
   @override

--- a/test/flutter_intercom_test.dart
+++ b/test/flutter_intercom_test.dart
@@ -9,41 +9,85 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 class MockFlutterIntercomPlatform
     with MockPlatformInterfaceMixin
     implements FlutterIntercomPlatform {
+  bool setApiKeyForAppIdCalled = false;
+  bool presentCalled = false;
+  bool logoutCalled = false;
 
   @override
-  Future<void> setApiKeyForAppId({String? apiKey, String? appId}) => Future.value();
+  Future<void> setApiKeyForAppId({String? apiKey, String? appId}) async {
+    setApiKeyForAppIdCalled = true;
+  }
 
   @override
-  Future<ICMLoginResult> loginUnidentifiedUser() => Future.value(ICMLoginResult());
+  Future<ICMLoginResult> loginUnidentifiedUser() =>
+      Future.value(ICMLoginResult());
 
   @override
-  Future<ICMLoginResult> loginUser(ICMUserAttributes userAttributes) => Future.value(ICMLoginResult());
+  Future<ICMLoginResult> loginUser(ICMUserAttributes userAttributes) =>
+      Future.value(ICMLoginResult());
 
   @override
   Future<void> setUserHash(String hash) => Future.value();
 
   @override
-  Future<void> present(ICMSpace? space) => Future.value();
+  Future<void> present(ICMSpace? space) async {
+    presentCalled = true;
+  }
 
   @override
   Future<void> hide() => Future.value();
 
   @override
-  Future<void> logout() => Future.value();
+  Future<void> logout() async {
+    logoutCalled = true;
+  }
 }
 
 void main() {
-  final FlutterIntercomPlatform initialPlatform = FlutterIntercomPlatform.instance;
+  final FlutterIntercomPlatform initialPlatform =
+      FlutterIntercomPlatform.instance;
 
   test('$MethodChannelFlutterIntercom is the default instance', () {
     expect(initialPlatform, isInstanceOf<MethodChannelFlutterIntercom>());
   });
 
-  test('setApiKeyForAppId', () async {
-    FlutterIntercom flutterIntercomPlugin = FlutterIntercom();
-    MockFlutterIntercomPlatform fakePlatform = MockFlutterIntercomPlatform();
-    FlutterIntercomPlatform.instance = fakePlatform;
+  late FlutterIntercom flutterIntercomPlugin;
+  late MockFlutterIntercomPlatform fakePlatform;
 
-    expect(await flutterIntercomPlugin.loginUnidentifiedUser(), isNull);
+  setUp(() {
+    flutterIntercomPlugin = FlutterIntercom();
+    fakePlatform = MockFlutterIntercomPlatform();
+    FlutterIntercomPlatform.instance = fakePlatform;
+    FlutterIntercomPlatform.isPresent = false;
+  });
+
+  tearDown(() {
+    FlutterIntercomPlatform.instance = initialPlatform;
+    FlutterIntercomPlatform.isPresent = false;
+  });
+
+  test('setApiKeyForAppId forwards initialization to platform', () async {
+    await flutterIntercomPlugin.setApiKeyForAppId(
+      apiKey: 'api-key',
+      appId: 'app-id',
+    );
+
+    expect(fakePlatform.setApiKeyForAppIdCalled, isTrue);
+  });
+
+  test('present always forwards to platform and marks UI as present', () async {
+    await flutterIntercomPlugin.present(space: ICMSpace.home);
+
+    expect(fakePlatform.presentCalled, isTrue);
+    expect(FlutterIntercomPlatform.isPresent, isTrue);
+  });
+
+  test('logout calls platform and resets present state', () async {
+    await flutterIntercomPlugin.present(space: ICMSpace.home);
+
+    await flutterIntercomPlugin.logout();
+
+    expect(fakePlatform.logoutCalled, isTrue);
+    expect(FlutterIntercomPlatform.isPresent, isFalse);
   });
 }


### PR DESCRIPTION
## Description
**问题描述:**
Firebase Crashlytics 上报 Intercom Android SDK 在未初始化状态下启动/调用时可能抛出 `IntercomIntegrationException`。当前 `flutter_intercom` 插件只有 `setApiKeyForAppId` 会初始化 SDK，其他公开 API 会直接调用 Intercom SDK；如果主 app 在初始化失败、初始化尚未完成、登出后或业务流程异常时调用 `login/present/hide/logout/setUserHash`，存在触发原生异常的风险。

**解决方案:**
1. Android/iOS 原生插件增加 SDK 初始化状态 guard，未初始化时不再直接调用 Intercom SDK
2. Android 初始化失败时返回 `INTERCOM_INITIALIZE_ERROR`，避免 Dart 层静默吞掉初始化失败
3. Dart 层移除初始化状态拦截，所有调用交由 native guard 判断，避免 Flutter engine/isolate 重建后误判
4. `present/hide/logout` 改为等待 platform 调用完成后再更新 Dart 展示状态
5. 更新插件单元测试，覆盖初始化转发、present 状态和 logout 状态重置

## Lark To-Do URL

https://project.larksuite.com/lifecycle/bugs/detail/12029400

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] FF cleanup (non-breaking change which is clean up of old feature flags)
- [ ] Optimization (non-breaking change which improves performance)
- [ ] Refactor (non-breaking change that improves code structure or readability without altering functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my codes locally
- [x] I have updated necessary documentation (if appropriate)
- [ ] I have change pubspec.yaml

## Verification

- `flutter test`
- `flutter analyze`
- `git diff --check`